### PR TITLE
Fix foreign_keys parameter syntax in User model relationships

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -81,8 +81,8 @@ class User(Base):
 
     # Relationships
     service_requests = relationship("ServiceRequest", back_populates="created_by_user")
-    test_executions = relationship("TestExecution", foreign_keys="[TestExecution.technician_id]", back_populates="technician_user")
-    reviewed_executions = relationship("TestExecution", foreign_keys="[TestExecution.reviewer_id]", back_populates="reviewer_user")
+    test_executions = relationship("TestExecution", foreign_keys=lambda: [TestExecution.technician_id], back_populates="technician_user")
+    reviewed_executions = relationship("TestExecution", foreign_keys=lambda: [TestExecution.reviewer_id], back_populates="reviewer_user")
     audit_logs = relationship("AuditLog", back_populates="user")
 
     def __repr__(self):


### PR DESCRIPTION
Changed foreign_keys from string format to lambda functions in the User class relationships to resolve SQLAlchemy InvalidRequestError. The correct syntax for forward-declared models uses lambda functions to defer evaluation:
- test_executions: foreign_keys=lambda: [TestExecution.technician_id]
- reviewed_executions: foreign_keys=lambda: [TestExecution.reviewer_id]

This fixes the issue where foreign_keys="[TestExecution.technician_id]" was being treated as a literal string rather than a list reference.