### PR TITLE
Rollback: Restore Test_Protocols.py to working state from commit 9f5a46e

### DIFF
--- a/pages/5_🔬_Test_Protocols.py
+++ b/pages/5_🔬_Test_Protocols.py
@@ -18,7 +18,7 @@ from config.database import get_db
 from config.protocols_registry import get_cached_protocol_registry
 from components.navigation import render_header, render_sidebar_navigation
 from components.visualizations import create_iv_curve, create_pv_curve, render_test_summary_card
-from database.models import TestExecution, TestProtocol, ServiceRequest, TestStatus, TestData
+from database import TestExecution, TestProtocol, ServiceRequest, TestStatus, TestData
 from sqlalchemy import select, desc, asc, and_, or_, func
 
 # Page configuration
@@ -146,11 +146,9 @@ def render_test_execution():
 
     # Link to service request - extract data before session closes to avoid DetachedInstanceError
     with get_db() as db:
-        service_requests = db.execute(
-            select(ServiceRequest).where(
-                ServiceRequest.status.in_(['approved', 'in_progress'])
-            )
-        ).scalars().all()
+        service_requests = db.query(ServiceRequest).filter(
+            ServiceRequest.status.in_(['approved', 'in_progress'])
+        ).all()
         # Extract needed data while session is still open
         sr_options = {
             f"{sr.request_number} - {sr.client_name}": sr.id
@@ -491,17 +489,13 @@ def render_test_results_checksheet():
     # Get active test executions (in_progress or pending_review)
     try:
         with get_db() as db:
-            active_executions = db.execute(
-                select(TestExecution).where(
-                    TestExecution.status.in_([TestStatus.IN_PROGRESS, TestStatus.NOT_STARTED, TestStatus.PENDING_REVIEW])
-                ).order_by(TestExecution.created_at.desc())
-            ).scalars().all()
+            active_executions = db.query(TestExecution).filter(
+                TestExecution.status.in_([TestStatus.IN_PROGRESS, TestStatus.NOT_STARTED, TestStatus.PENDING_REVIEW])
+            ).order_by(TestExecution.created_at.desc()).all()
 
-            completed_executions = db.execute(
-                select(TestExecution).where(
-                    TestExecution.status == TestStatus.COMPLETED
-                ).order_by(TestExecution.completed_at.desc()).limit(10)
-            ).scalars().all()
+            completed_executions = db.query(TestExecution).filter(
+                TestExecution.status == TestStatus.COMPLETED
+            ).order_by(TestExecution.completed_at.desc()).limit(10).all()
 
     except Exception as e:
         st.error(f"Error loading executions: {str(e)}")
@@ -607,9 +601,7 @@ def render_test_results_checksheet():
                         if start_test:
                             try:
                                 with get_db() as db:
-                                    exec_record = db.execute(
-                                        select(TestExecution).where(TestExecution.id == execution.id)
-                                    ).scalars().first()
+                                    exec_record = db.query(TestExecution).filter(TestExecution.id == execution.id).first()
                                     exec_record.status = TestStatus.IN_PROGRESS
                                     exec_record.started_at = datetime.utcnow()
                                     db.commit()
@@ -621,9 +613,7 @@ def render_test_results_checksheet():
                         if complete_test:
                             try:
                                 with get_db() as db:
-                                    exec_record = db.execute(
-                                        select(TestExecution).where(TestExecution.id == execution.id)
-                                    ).scalars().first()
+                                    exec_record = db.query(TestExecution).filter(TestExecution.id == execution.id).first()
                                     exec_record.status = TestStatus.COMPLETED
                                     exec_record.completed_at = datetime.utcnow()
                                     db.commit()
@@ -635,11 +625,9 @@ def render_test_results_checksheet():
                     # Show existing data points
                     try:
                         with get_db() as db:
-                            data_points = db.execute(
-                                select(TestData).where(
-                                    TestData.test_execution_id == execution.id
-                                ).order_by(TestData.timestamp.desc())
-                            ).scalars().all()
+                            data_points = db.query(TestData).filter(
+                                TestData.test_execution_id == execution.id
+                            ).order_by(TestData.timestamp.desc()).all()
 
                             if data_points:
                                 st.markdown("**Recorded Data Points:**")
@@ -658,11 +646,9 @@ def render_test_results_checksheet():
         # Get service requests
         try:
             with get_db() as db:
-                service_requests = db.execute(
-                    select(ServiceRequest).where(
-                        ServiceRequest.status.in_(['approved', 'in_progress'])
-                    )
-                ).scalars().all()
+                service_requests = db.query(ServiceRequest).filter(
+                    ServiceRequest.status.in_(['approved', 'in_progress'])
+                ).all()
         except:
             service_requests = []
 
@@ -760,11 +746,9 @@ def render_test_history():
 
     try:
         with get_db() as db:
-            executions = db.execute(
-                select(TestExecution).order_by(
-                    TestExecution.created_at.desc()
-                ).limit(20)
-            ).scalars().all()
+            executions = db.query(TestExecution).order_by(
+                TestExecution.created_at.desc()
+            ).limit(20).all()
 
             if not executions:
                 st.info("No test executions found")


### PR DESCRIPTION
Reverts to the last known working version before the IndentationError was introduced. This version may have DetachedInstanceError (runtime) but the page will load.