### PR TITLE
fix: correct indentation error in Test_Protocols.py at line 195

### DIFF
--- a/pages/5_🔬_Test_Protocols.py
+++ b/pages/5_🔬_Test_Protocols.py
@@ -192,10 +192,10 @@ def render_test_execution():
             ServiceRequest.status.in_(['approved', 'in_progress'])
         ).all()
         # Extract needed data while session is still open
-            sr_options = {
-                f"{sr.request_number} - {sr.client_name}": sr.id
-                for sr in service_requests
-            }
+        sr_options = {
+            f"{sr.request_number} - {sr.client_name}": sr.id
+            for sr in service_requests
+        }
 
     if not sr_options:
         st.warning("No approved service requests available. Create a service request first.")


### PR DESCRIPTION
The sr_options dictionary had incorrect indentation (12 spaces instead of 8) causing an IndentationError in production. Fixed to use consistent 4-space indentation within the `with get_db()` block.