### PR TITLE
fix: Define sr_options variable before use in render_test_results_che…

### DIFF
--- a/pages/5_🔬_Test_Protocols.py
+++ b/pages/5_🔬_Test_Protocols.py
@@ -704,8 +704,13 @@ def render_test_results_checksheet():
                 service_requests = db.query(ServiceRequest).filter(
                     ServiceRequest.status.in_(['approved', 'in_progress'])
                 ).all()
+                # Extract needed data while session is still open
+                sr_options = {
+                    f"{sr.request_number} - {sr.client_name}": sr.id
+                    for sr in service_requests
+                }
         except:
-            service_requests = []
+            sr_options = {}
 
         if not sr_options:
             st.warning("No approved service requests available. Create a service request first.")


### PR DESCRIPTION
…cksheet

The sr_options dictionary was referenced on line 710 but never defined. The code fetched service_requests from the database but failed to create the sr_options dictionary from it, causing a NameError at runtime.

Fixed by constructing sr_options inside the get_db() context block, matching the pattern used elsewhere in the file (line 195).