### PR TITLE
fix: Seed all 54 test protocols to fix ForeignKeyViolation on test_ex…

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -5,16 +5,20 @@ Handles database initialization, session management, and connection pooling.
 """
 
 import os
+import logging
 from contextlib import contextmanager
-from typing import Generator
+from typing import Generator, List, Dict, Any
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, select
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import StaticPool
 import streamlit as st
 
 from config.settings import config
+
+# Set up logger
+logger = logging.getLogger(__name__)
 
 # Create declarative base for models
 Base = declarative_base()
@@ -94,9 +98,676 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
+def get_all_protocols_data() -> List[Dict[str, Any]]:
+    """
+    Get all 54 protocol definitions for database seeding.
+    This mirrors the protocol data from protocols_registry.py.
+
+    Returns:
+        List of protocol dictionaries with all metadata
+    """
+    return [
+        # =============================================
+        # PERFORMANCE TESTING (P1-P12) - 12 protocols
+        # =============================================
+        {
+            "protocol_id": "P1",
+            "name": "I-V Performance Characterization",
+            "category": "performance",
+            "description": "Measure current-voltage characteristics under STC (Standard Test Conditions)",
+            "standard_reference": "IEC 61215-2:2021 MQT 06",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["solar_simulator", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P2",
+            "name": "P-V Performance Analysis",
+            "category": "performance",
+            "description": "Power-voltage characteristic measurement and maximum power point analysis",
+            "standard_reference": "IEC 61215-2:2021 MQT 06",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["solar_simulator", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P3",
+            "name": "STC Power Rating",
+            "category": "performance",
+            "description": "Power rating at Standard Test Conditions (1000 W/m², 25°C, AM1.5G)",
+            "standard_reference": "IEC 61215-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["solar_simulator", "iv_tracer", "reference_cell"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P4",
+            "name": "NOCT Determination",
+            "category": "performance",
+            "description": "Nominal Operating Cell Temperature determination",
+            "standard_reference": "IEC 61215-2:2021 MQT 05",
+            "version": "1.0.0",
+            "estimated_duration_hours": 8.0,
+            "required_equipment": ["outdoor_test_stand", "temperature_sensors", "pyranometer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P5",
+            "name": "Temperature Coefficient Measurement",
+            "category": "performance",
+            "description": "Determine temperature coefficients for Isc, Voc, and Pmax",
+            "standard_reference": "IEC 61215-2:2021 MQT 04",
+            "version": "1.0.0",
+            "estimated_duration_hours": 6.0,
+            "required_equipment": ["solar_simulator", "climate_chamber", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P6",
+            "name": "Low Irradiance Performance",
+            "category": "performance",
+            "description": "Performance measurement at 200 W/m² irradiance",
+            "standard_reference": "IEC 61215-2:2021 MQT 07",
+            "version": "1.0.0",
+            "estimated_duration_hours": 3.0,
+            "required_equipment": ["solar_simulator", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P7",
+            "name": "Performance Matrix Test",
+            "category": "performance",
+            "description": "Multi-condition performance mapping (IEC 61853-1)",
+            "standard_reference": "IEC 61853-1:2011",
+            "version": "1.0.0",
+            "estimated_duration_hours": 24.0,
+            "required_equipment": ["solar_simulator", "climate_chamber", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P8",
+            "name": "Spectral Response Measurement",
+            "category": "performance",
+            "description": "Measure spectral response and quantum efficiency",
+            "standard_reference": "IEC 60904-8:2014",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["spectral_response_system", "monochromator"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P9",
+            "name": "Incidence Angle Modifier (IAM)",
+            "category": "performance",
+            "description": "Measure power output vs. angle of incidence",
+            "standard_reference": "IEC 61853-2:2016",
+            "version": "1.0.0",
+            "estimated_duration_hours": 6.0,
+            "required_equipment": ["solar_simulator", "rotatable_mount", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P10",
+            "name": "Bifacial Performance Test",
+            "category": "performance",
+            "description": "Characterization of bifacial module performance and bifaciality factor",
+            "standard_reference": "IEC TS 60904-1-2:2019",
+            "version": "1.0.0",
+            "estimated_duration_hours": 8.0,
+            "required_equipment": ["solar_simulator", "iv_tracer", "albedo_reflector"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P11",
+            "name": "Energy Rating Test",
+            "category": "performance",
+            "description": "Energy yield prediction and rating under reference conditions",
+            "standard_reference": "IEC 61853-3:2018",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["solar_simulator", "iv_tracer", "energy_rating_software"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P12",
+            "name": "Bypass Diode Functionality",
+            "category": "performance",
+            "description": "Verify bypass diode operation under partial shading",
+            "standard_reference": "IEC 61215-2:2021 MQT 18",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["solar_simulator", "iv_tracer", "thermal_camera"],
+            "is_active": True
+        },
+        # =============================================
+        # DEGRADATION TESTING (P13-P27) - 15 protocols
+        # =============================================
+        {
+            "protocol_id": "P13",
+            "name": "Light-Induced Degradation (LID)",
+            "category": "degradation",
+            "description": "Assess power degradation under continuous light exposure",
+            "standard_reference": "IEC 61215-2:2021 MQT 19",
+            "version": "1.0.0",
+            "estimated_duration_hours": 48.0,
+            "required_equipment": ["solar_simulator", "climate_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P14",
+            "name": "Light & Elevated Temperature ID (LETID)",
+            "category": "degradation",
+            "description": "Light and elevated temperature induced degradation test",
+            "standard_reference": "IEC TS 63202-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 162.0,
+            "required_equipment": ["solar_simulator", "climate_chamber", "iv_tracer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P15",
+            "name": "Potential-Induced Degradation (PID)",
+            "category": "degradation",
+            "description": "Test for voltage stress induced degradation",
+            "standard_reference": "IEC TS 62804-1:2015",
+            "version": "1.0.0",
+            "estimated_duration_hours": 96.0,
+            "required_equipment": ["pid_test_chamber", "high_voltage_source"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P16",
+            "name": "PID Recovery Test",
+            "category": "degradation",
+            "description": "Evaluate PID reversibility under recovery conditions",
+            "standard_reference": "IEC TS 62804-1:2015",
+            "version": "1.0.0",
+            "estimated_duration_hours": 48.0,
+            "required_equipment": ["pid_test_chamber", "high_voltage_source"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P17",
+            "name": "UV Degradation Test",
+            "category": "degradation",
+            "description": "Assess degradation from UV exposure (UV preconditioning)",
+            "standard_reference": "IEC 61215-2:2021 MQT 10",
+            "version": "1.0.0",
+            "estimated_duration_hours": 120.0,
+            "required_equipment": ["uv_exposure_chamber", "uv_lamp_array"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P18",
+            "name": "Hot Spot Endurance Test",
+            "category": "degradation",
+            "description": "Verify module resilience to localized heating (hot spots)",
+            "standard_reference": "IEC 61215-2:2021 MQT 09",
+            "version": "1.0.0",
+            "estimated_duration_hours": 5.0,
+            "required_equipment": ["solar_simulator", "thermal_camera", "shading_masks"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P19",
+            "name": "Snail Trail Assessment",
+            "category": "degradation",
+            "description": "Visual and electrical assessment of snail trail formation",
+            "standard_reference": "IEC 62759-1:2015",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["el_imaging_system", "visual_inspection_station"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P20",
+            "name": "Cell Crack Detection",
+            "category": "degradation",
+            "description": "Electroluminescence imaging for micro-crack detection",
+            "standard_reference": "IEC TS 60904-13:2018",
+            "version": "1.0.0",
+            "estimated_duration_hours": 1.0,
+            "required_equipment": ["el_imaging_system", "power_supply"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P21",
+            "name": "Solder Bond Degradation",
+            "category": "degradation",
+            "description": "Evaluate solder joint integrity and interconnect degradation",
+            "standard_reference": "IEC 61215-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["el_imaging_system", "thermal_camera"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P22",
+            "name": "Delamination Assessment",
+            "category": "degradation",
+            "description": "Identify and quantify delamination in module layers",
+            "standard_reference": "IEC 61215-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["visual_inspection_station", "el_imaging_system"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P23",
+            "name": "Yellowing/Browning Test",
+            "category": "degradation",
+            "description": "Assess encapsulant discoloration and its effect on performance",
+            "standard_reference": "IEC 62788-1-6:2017",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["colorimeter", "spectrophotometer"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P24",
+            "name": "Corrosion Assessment",
+            "category": "degradation",
+            "description": "Evaluate corrosion of metallic components and interconnects",
+            "standard_reference": "IEC 61701:2020",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["visual_inspection_station", "multimeter"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P25",
+            "name": "Backsheet Chalking Test",
+            "category": "degradation",
+            "description": "Assess backsheet surface degradation and chalking",
+            "standard_reference": "IEC 62788-2-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 1.0,
+            "required_equipment": ["adhesion_tester", "visual_inspection_station"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P26",
+            "name": "Junction Box Degradation",
+            "category": "degradation",
+            "description": "Evaluate junction box integrity and connector condition",
+            "standard_reference": "IEC 62790:2020",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["insulation_tester", "multimeter"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P27",
+            "name": "Long-term Outdoor Exposure",
+            "category": "degradation",
+            "description": "Natural weathering and outdoor degradation monitoring",
+            "standard_reference": "IEC 61215-1:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 8760.0,
+            "required_equipment": ["outdoor_test_rack", "weather_station", "data_logger"],
+            "is_active": True
+        },
+        # =============================================
+        # ENVIRONMENTAL TESTING (P28-P39) - 12 protocols
+        # =============================================
+        {
+            "protocol_id": "P28",
+            "name": "Humidity Freeze Test",
+            "category": "environmental",
+            "description": "Assess module resistance to humidity freeze cycles (10 cycles)",
+            "standard_reference": "IEC 61215-2:2021 MQT 12",
+            "version": "1.0.0",
+            "estimated_duration_hours": 240.0,
+            "required_equipment": ["climate_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P29",
+            "name": "Damp Heat Test (1000h)",
+            "category": "environmental",
+            "description": "Exposure to 85°C/85% RH for 1000 hours",
+            "standard_reference": "IEC 61215-2:2021 MQT 13",
+            "version": "1.0.0",
+            "estimated_duration_hours": 1000.0,
+            "required_equipment": ["climate_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P30",
+            "name": "Damp Heat Extended (2000h)",
+            "category": "environmental",
+            "description": "Extended damp heat test for enhanced durability",
+            "standard_reference": "IEC 61215-2:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2000.0,
+            "required_equipment": ["climate_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P31",
+            "name": "Thermal Cycling Test (200 cycles)",
+            "category": "environmental",
+            "description": "Temperature cycling from -40°C to +85°C (200 cycles)",
+            "standard_reference": "IEC 61215-2:2021 MQT 11",
+            "version": "1.0.0",
+            "estimated_duration_hours": 800.0,
+            "required_equipment": ["thermal_cycling_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P32",
+            "name": "Salt Mist Corrosion Test",
+            "category": "environmental",
+            "description": "Exposure to salt spray for coastal environment simulation",
+            "standard_reference": "IEC 61701:2020",
+            "version": "1.0.0",
+            "estimated_duration_hours": 500.0,
+            "required_equipment": ["salt_spray_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P33",
+            "name": "Ammonia Corrosion Test",
+            "category": "environmental",
+            "description": "Ammonia exposure for agricultural environment simulation",
+            "standard_reference": "IEC 62716:2013",
+            "version": "1.0.0",
+            "estimated_duration_hours": 500.0,
+            "required_equipment": ["ammonia_test_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P34",
+            "name": "Sand/Dust Abrasion Test",
+            "category": "environmental",
+            "description": "Sand and dust abrasion resistance testing",
+            "standard_reference": "IEC 60068-2-68:1994",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["sand_dust_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P35",
+            "name": "SO2/H2S Corrosion Test",
+            "category": "environmental",
+            "description": "Sulfur dioxide and hydrogen sulfide exposure",
+            "standard_reference": "IEC 60068-2-42:2003",
+            "version": "1.0.0",
+            "estimated_duration_hours": 240.0,
+            "required_equipment": ["corrosive_gas_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P36",
+            "name": "Desert Climate Simulation",
+            "category": "environmental",
+            "description": "High temperature, low humidity, and UV stress testing",
+            "standard_reference": "IEC 62892:2019",
+            "version": "1.0.0",
+            "estimated_duration_hours": 720.0,
+            "required_equipment": ["climate_chamber", "uv_lamp_array"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P37",
+            "name": "Tropical Climate Simulation",
+            "category": "environmental",
+            "description": "High humidity and temperature cycling for tropical environments",
+            "standard_reference": "IEC 62892:2019",
+            "version": "1.0.0",
+            "estimated_duration_hours": 720.0,
+            "required_equipment": ["climate_chamber"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P38",
+            "name": "Snow Load Test",
+            "category": "environmental",
+            "description": "Static load test simulating accumulated snow",
+            "standard_reference": "IEC 61215-2:2021 MQT 16",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["mechanical_load_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P39",
+            "name": "UV Exposure Test",
+            "category": "environmental",
+            "description": "Accelerated UV exposure (15 kWh/m² minimum)",
+            "standard_reference": "IEC 61215-2:2021 MQT 10",
+            "version": "1.0.0",
+            "estimated_duration_hours": 120.0,
+            "required_equipment": ["uv_exposure_chamber"],
+            "is_active": True
+        },
+        # =============================================
+        # MECHANICAL TESTING (P40-P47) - 8 protocols
+        # =============================================
+        {
+            "protocol_id": "P40",
+            "name": "Mechanical Load Test",
+            "category": "mechanical",
+            "description": "Static and cyclic mechanical load testing (2400 Pa / 5400 Pa)",
+            "standard_reference": "IEC 61215-2:2021 MQT 16",
+            "version": "1.0.0",
+            "estimated_duration_hours": 8.0,
+            "required_equipment": ["mechanical_load_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P41",
+            "name": "Dynamic Mechanical Load",
+            "category": "mechanical",
+            "description": "Dynamic loading cycles (1000 cycles at 1000 Pa)",
+            "standard_reference": "IEC TS 62782:2016",
+            "version": "1.0.0",
+            "estimated_duration_hours": 24.0,
+            "required_equipment": ["dynamic_load_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P42",
+            "name": "Hail Impact Test",
+            "category": "mechanical",
+            "description": "Impact resistance test with ice balls (25mm @ 23 m/s)",
+            "standard_reference": "IEC 61215-2:2021 MQT 17",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["hail_impact_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P43",
+            "name": "Wind Load Simulation",
+            "category": "mechanical",
+            "description": "Cyclic wind load simulation for structural integrity",
+            "standard_reference": "IEC 61215-2:2021 MQT 16",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["mechanical_load_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P44",
+            "name": "Module Twist Test",
+            "category": "mechanical",
+            "description": "Torsional stress test for frame and laminate integrity",
+            "standard_reference": "IEC 62892:2019",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["twist_test_fixture"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P45",
+            "name": "Vibration Test",
+            "category": "mechanical",
+            "description": "Transportation and installation vibration simulation",
+            "standard_reference": "IEC 60068-2-6:2007",
+            "version": "1.0.0",
+            "estimated_duration_hours": 6.0,
+            "required_equipment": ["vibration_table"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P46",
+            "name": "Frame/Mounting Stress Test",
+            "category": "mechanical",
+            "description": "Mounting point load test and frame integrity verification",
+            "standard_reference": "IEC 61215-2:2021",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["mechanical_load_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P47",
+            "name": "Robustness of Terminations",
+            "category": "mechanical",
+            "description": "Pull and push test on cables and connectors",
+            "standard_reference": "IEC 61215-2:2021 MQT 14",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["force_gauge", "pull_tester"],
+            "is_active": True
+        },
+        # =============================================
+        # SAFETY & ELECTRICAL TESTING (P48-P54) - 7 protocols
+        # =============================================
+        {
+            "protocol_id": "P48",
+            "name": "Wet Leakage Current Test",
+            "category": "safety",
+            "description": "Measure leakage current under wet conditions",
+            "standard_reference": "IEC 61215-2:2021 MQT 15",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["insulation_tester", "wetting_system"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P49",
+            "name": "Insulation Resistance Test",
+            "category": "safety",
+            "description": "Dry insulation resistance measurement (1000V DC)",
+            "standard_reference": "IEC 61215-2:2021 MQT 03",
+            "version": "1.0.0",
+            "estimated_duration_hours": 1.0,
+            "required_equipment": ["insulation_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P50",
+            "name": "Dielectric Withstand Test",
+            "category": "safety",
+            "description": "High voltage insulation test (system voltage + 1000V)",
+            "standard_reference": "IEC 61730-2:2016 MST 16",
+            "version": "1.0.0",
+            "estimated_duration_hours": 1.0,
+            "required_equipment": ["hipot_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P51",
+            "name": "Ground Continuity Test",
+            "category": "safety",
+            "description": "Frame grounding and continuity verification",
+            "standard_reference": "IEC 61730-2:2016 MST 13",
+            "version": "1.0.0",
+            "estimated_duration_hours": 0.5,
+            "required_equipment": ["continuity_tester"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P52",
+            "name": "Fire Resistance Test",
+            "category": "safety",
+            "description": "Spread of flame test for building-integrated applications",
+            "standard_reference": "IEC 61730-2:2016 MST 23-25",
+            "version": "1.0.0",
+            "estimated_duration_hours": 4.0,
+            "required_equipment": ["fire_test_apparatus"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P53",
+            "name": "Reverse Current Overload",
+            "category": "safety",
+            "description": "Bypass diode thermal test under reverse current",
+            "standard_reference": "IEC 61215-2:2021 MQT 18",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["power_supply", "thermal_camera"],
+            "is_active": True
+        },
+        {
+            "protocol_id": "P54",
+            "name": "Impulse Voltage Test",
+            "category": "safety",
+            "description": "Lightning impulse withstand test (1.2/50 μs)",
+            "standard_reference": "IEC 61730-2:2016 MST 14",
+            "version": "1.0.0",
+            "estimated_duration_hours": 2.0,
+            "required_equipment": ["impulse_voltage_generator"],
+            "is_active": True
+        },
+    ]
+
+
+def seed_protocols(db: Session) -> int:
+    """
+    Seed all 54 test protocols into the database.
+    This function is idempotent - it will only insert protocols that don't exist.
+
+    Args:
+        db: Database session
+
+    Returns:
+        Number of protocols inserted
+    """
+    from database.models import TestProtocol
+
+    protocols_data = get_all_protocols_data()
+    inserted_count = 0
+
+    for protocol_data in protocols_data:
+        # Check if protocol already exists (idempotent)
+        stmt = select(TestProtocol).where(
+            TestProtocol.protocol_id == protocol_data["protocol_id"]
+        )
+        existing = db.execute(stmt).scalar_one_or_none()
+
+        if existing is None:
+            # Create new protocol with all metadata
+            new_protocol = TestProtocol(
+                protocol_id=protocol_data["protocol_id"],
+                name=protocol_data["name"],
+                category=protocol_data["category"],
+                description=protocol_data["description"],
+                standard_reference=protocol_data["standard_reference"],
+                version=protocol_data["version"],
+                estimated_duration_hours=protocol_data["estimated_duration_hours"],
+                required_equipment=protocol_data["required_equipment"],
+                is_active=protocol_data["is_active"]
+            )
+            db.add(new_protocol)
+            inserted_count += 1
+
+    if inserted_count > 0:
+        db.commit()
+        logger.info(f"Seeded {inserted_count} test protocols into database")
+
+    return inserted_count
+
+
 def init_database():
     """
-    Initialize database - create all tables
+    Initialize database - create all tables and seed protocols
 
     Returns:
         Database session factory
@@ -110,8 +781,7 @@ def init_database():
 
     engine = get_engine()
 
-
-        # CRITICAL FIX: Configure mappers before creating tables
+    # CRITICAL FIX: Configure mappers before creating tables
     # This ensures all relationships are properly set up
     from sqlalchemy.orm import configure_mappers
     try:
@@ -121,6 +791,7 @@ def init_database():
         from sqlalchemy.orm import clear_mappers
         clear_mappers()
         configure_mappers()
+
     # Create all tables
     Base.metadata.create_all(bind=engine)
 
@@ -129,11 +800,10 @@ def init_database():
 
     # Create default admin user if not exists
     with get_db() as db:
-        admin_exists = db.query(User).filter_by(username="admin").first()
+        stmt = select(User).where(User.username == "admin")
+        admin_exists = db.execute(stmt).scalar_one_or_none()
 
         if not admin_exists:
-
-
             admin_user = User(
                 username="admin",
                 email="admin@solarpv.com",
@@ -144,24 +814,11 @@ def init_database():
             db.add(admin_user)
             db.commit()
 
-        # Seed test protocols if table is empty
-    protocols_count = db.query(TestProtocol).count()
-    if protocols_count == 0:
-        protocols = [
-            TestProtocol(protocol_id="P1", name="I-V Performance Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P2", name="PMax Tracking Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P3", name="Temperature Coefficient", category="performance", is_active=True),
-            TestProtocol(protocol_id="P4", name="Module Thermal Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P5", name="Humidity-Freeze Test", category="environmental", is_active=True),
-            TestProtocol(protocol_id="P6", name="Hot-Humid Test", category="environmental", is_active=True),
-            TestProtocol(protocol_id="P7", name="Thermal Cycling Test", category="degradation", is_active=True),
-            TestProtocol(protocol_id="P8", name="UV Degradation Test", category="degradation", is_active=True),
-            TestProtocol(protocol_id="P9", name="Mechanical Load Test", category="mechanical", is_active=True),
-            TestProtocol(protocol_id="P10", name="Wet Leakage Test", category="safety", is_active=True),
-        ]
-        for protocol in protocols:
-            db.add(protocol)
-        db.commit()
+    # Seed all 54 test protocols (idempotent - only inserts missing protocols)
+    with get_db() as db:
+        inserted_count = seed_protocols(db)
+        if inserted_count > 0:
+            logger.info(f"Database initialized with {inserted_count} new protocols")
 
     return SessionLocal
 


### PR DESCRIPTION
…ecutions

- Add get_all_protocols_data() with complete metadata for all 54 protocols
- Add seed_protocols() function with idempotent insertion logic
- Fix indentation bug in init_database() where protocol seeding was outside db context
- Replace deprecated .query() with SQLAlchemy 2.0 select() syntax
- Protocols now include: description, standard_reference, version, estimated_duration_hours, required_equipment

This fixes the error:
  psycopg2.errors.ForeignKeyViolation: Key (protocol_id)=(1) is not present in table "test_protocols"