### PR TITLE
fix: Implement idempotent protocol seeding to prevent ForeignKeyViola…

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -132,8 +132,6 @@ def init_database():
         admin_exists = db.query(User).filter_by(username="admin").first()
 
         if not admin_exists:
-
-
             admin_user = User(
                 username="admin",
                 email="admin@solarpv.com",
@@ -144,26 +142,52 @@ def init_database():
             db.add(admin_user)
             db.commit()
 
-        # Seed test protocols if table is empty
-    protocols_count = db.query(TestProtocol).count()
-    if protocols_count == 0:
-        protocols = [
-            TestProtocol(protocol_id="P1", name="I-V Performance Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P2", name="PMax Tracking Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P3", name="Temperature Coefficient", category="performance", is_active=True),
-            TestProtocol(protocol_id="P4", name="Module Thermal Test", category="performance", is_active=True),
-            TestProtocol(protocol_id="P5", name="Humidity-Freeze Test", category="environmental", is_active=True),
-            TestProtocol(protocol_id="P6", name="Hot-Humid Test", category="environmental", is_active=True),
-            TestProtocol(protocol_id="P7", name="Thermal Cycling Test", category="degradation", is_active=True),
-            TestProtocol(protocol_id="P8", name="UV Degradation Test", category="degradation", is_active=True),
-            TestProtocol(protocol_id="P9", name="Mechanical Load Test", category="mechanical", is_active=True),
-            TestProtocol(protocol_id="P10", name="Wet Leakage Test", category="safety", is_active=True),
-        ]
-        for protocol in protocols:
-            db.add(protocol)
-        db.commit()
+    # CRITICAL FIX: Seed test protocols if not all are present
+    # This runs EVERY TIME init_database() is called to handle partial seeding
+    _seed_protocols_idempotent()
 
     return SessionLocal
+
+
+def _seed_protocols_idempotent():
+    """
+    Idempotent protocol seeding - seeds all 54 protocols if not fully populated.
+    Uses INSERT OR IGNORE logic to avoid duplicates.
+    """
+    from config.protocols_registry import ALL_54_PROTOCOLS
+
+    EXPECTED_PROTOCOL_COUNT = 54
+
+    with get_db() as db:
+        protocols_count = db.query(TestProtocol).count()
+
+        # Only seed if we have fewer than expected protocols
+        if protocols_count < EXPECTED_PROTOCOL_COUNT:
+            added_count = 0
+            for protocol_data in ALL_54_PROTOCOLS:
+                # Check if protocol already exists by protocol_id
+                existing = db.query(TestProtocol).filter_by(
+                    protocol_id=protocol_data["protocol_id"]
+                ).first()
+
+                if not existing:
+                    # Create TestProtocol with all available fields from the model
+                    protocol = TestProtocol(
+                        protocol_id=protocol_data["protocol_id"],
+                        name=protocol_data["name"],
+                        category=protocol_data["category"],
+                        description=protocol_data.get("description", ""),
+                        standard_reference=protocol_data.get("standard_reference", ""),
+                        estimated_duration_hours=protocol_data.get("estimated_duration_hours"),
+                        required_equipment=protocol_data.get("required_equipment", []),
+                        is_active=protocol_data.get("is_active", True),
+                    )
+                    db.add(protocol)
+                    added_count += 1
+
+            if added_count > 0:
+                db.commit()
+                print(f"✓ Seeded {added_count} test protocols (total: {protocols_count + added_count})")
 
 
 def reset_database():

--- a/config/protocols_registry.py
+++ b/config/protocols_registry.py
@@ -291,14 +291,8 @@ def get_protocol_registry() -> ProtocolRegistry:
     return _registry
 
 
-def register_sample_protocols(registry: ProtocolRegistry):
-    """
-    Register all 54 protocol definitions for Solar PV Testing
-    Based on IEC 61215, IEC 61730, and related standards
-    """
-
-    # All 54 protocols organized by category
-    all_protocols = [
+# All 54 protocols organized by category - exposed at module level for database seeding
+ALL_54_PROTOCOLS = [
         # =============================================
         # PERFORMANCE TESTING (P1-P12) - 12 protocols
         # =============================================
@@ -804,9 +798,15 @@ def register_sample_protocols(registry: ProtocolRegistry):
             "estimated_duration_hours": 2.0,
             "required_equipment": ["impulse_voltage_generator"]
         },
-    ]
+]
 
-    for protocol_data in all_protocols:
+
+def register_sample_protocols(registry: ProtocolRegistry):
+    """
+    Register all 54 protocol definitions for Solar PV Testing
+    Based on IEC 61215, IEC 61730, and related standards
+    """
+    for protocol_data in ALL_54_PROTOCOLS:
         metadata = ProtocolMetadata(**protocol_data)
         registry.register_protocol(metadata)
 


### PR DESCRIPTION
…tion

Root cause: The seeding condition `protocols_count == 0` only ran on first initialization. If the database existed with tables but no protocols (or partial protocols), seeding never happened, causing ForeignKeyViolation when saving test executions.

Changes:
- Change seeding to run if protocols_count < 54 (expected count)
- Add idempotent INSERT logic that checks if protocol exists before inserting
- Move ALL_54_PROTOCOLS to module level in protocols_registry.py for reuse
- Fix indentation bug where seeding code was outside the db context manager
- Seed all 54 IEC/IEEE standard protocols with full metadata